### PR TITLE
Remove Compat as dependency and more

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,11 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 0 * * * *
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ julia:
   - 1.1
   - 1.2
   - 1.3
+  - 1.4
   - nightly
 matrix:
   allow_failures:
+  - julia: 1.4
   - julia: nightly
 after_success:
  - julia --project -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -2,11 +2,7 @@ name = "FunctionWrappers"
 uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 version = "1.1.0"
 
-[deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-
 [compat]
-Compat = "2.2, 3.0"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FunctionWrappers"
 uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
-version = "1.1.0"
+version = "1.1.1"
 
 [compat]
 julia = "1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
   - julia_version: 1.1
   - julia_version: 1.2
   - julia_version: 1.3
+  - julia_version: 1.4
   - julia_version: nightly
 
 platform:
@@ -12,6 +13,7 @@ platform:
 
 matrix:
   allow_failures:
+  - julia_version: 1.4
   - julia_version: latest
 
 branches:

--- a/src/FunctionWrappers.jl
+++ b/src/FunctionWrappers.jl
@@ -4,8 +4,6 @@ __precompile__(true)
 
 module FunctionWrappers
 
-using Compat
-
 # Used to bypass NULL check
 @inline function assume(v::Bool)
     Base.llvmcall(("declare void @llvm.assume(i1)",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,7 @@
 
 import FunctionWrappers
 import FunctionWrappers: FunctionWrapper
-using Compat
-using Compat.Test
+using Test
 
 struct CallbackF64
     f::FunctionWrapper{Float64,Tuple{Int}}


### PR DESCRIPTION
I noticed that `Compat.Test` is deprecated. The test suite passes locally for me without Compat. This PR removes it as a dependency and bumps the version number for a patch release.

I'm not familiar with Compat, and I don't know what functionality it provided, so I won't merge this PR myself.

This PR also adds Julia TagBot for automatically tagging releases once registered and starts testing Julia 1.4 on Travis and Appveyor.