### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1.1'
+          - '1.2'
+          - '1.3'
+          - '1.4'
+          - '1'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+          - x86
+        # 32-bit Julia binaries are not available on macOS
+        exclude:
+          - os: macOS-latest
+            arch: x86
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # FunctionWrappers.jl: Type stable and efficient wrapper of arbitrary functions
 
+[![Build Status](https://github.com/yuyichao/FunctionWrappers.jl/workflows/CI/badge.svg)](https://github.com/yuyichao/FunctionWrappers.jl/actions)
 [![Build Status](https://travis-ci.org/yuyichao/FunctionWrappers.jl.svg?branch=master)](https://travis-ci.org/yuyichao/FunctionWrappers.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/mgearlsjllu4mdtd/branch/master?svg=true)](https://ci.appveyor.com/project/yuyichao/functionwrappers-jl/branch/master)
 [![codecov.io](http://codecov.io/github/yuyichao/FunctionWrappers.jl/coverage.svg?branch=master)](http://codecov.io/github/yuyichao/FunctionWrappers.jl?branch=master)


### PR DESCRIPTION
The Travis CI appears to have been broken for a while. Also none of the CI services test Julia 1.5. This PR adds a single GitHub Actions CI workflow that tests the same cases as both Travis and Appveyor.